### PR TITLE
Update Uncrustify to version 0.72.0+dfsg1-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-FROM debian:latest
+FROM ubuntu:jammy
 
 COPY entrypoint.sh /entrypoint.sh
 COPY default.cfg /default.cfg
+RUN chmod +x entrypoint.sh
 
 RUN apt-get update
-RUN apt-get -y install curl cmake build-essential python3 git colordiff
-RUN chmod +x entrypoint.sh
-RUN curl -L -o uncrustify-0.70.1.tar.gz https://github.com/uncrustify/uncrustify/archive/uncrustify-0.70.1.tar.gz
-RUN tar -xzf uncrustify-0.70.1.tar.gz
-WORKDIR /uncrustify-uncrustify-0.70.1
-RUN mkdir build
-WORKDIR /uncrustify-uncrustify-0.70.1/build
-RUN cmake ..
-RUN cmake --build .
-RUN cp uncrustify /usr/local/bin && chmod +x /usr/local/bin/uncrustify
+RUN apt-get -y install uncrustify=0.72.0+dfsg1-2 colordiff
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Dockerfile is modified to use the corresponding binary from ubuntu:jammy. 
This change reduces the build time (from 1 min 15 sec to 19 sec in my example).